### PR TITLE
chore: update dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,19 @@
 
 version: 2
 updates:
+
   - package-ecosystem: "cargo"
     directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+    # semver-incompatible updates will be handled manually
+    versioning-strategy: "lockfile-only"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "weekly"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -7,6 +7,8 @@ license.workspace = true
 homepage.workspace = true
 repository.workspace = true
 rust-version.workspace = true
+# https://github.com/dependabot/dependabot-core/issues/1156
+autobins = false
 
 build = "../build.rs"
 


### PR DESCRIPTION
- Check github-actions updates.
- Configure dependabot to send a weekly batch of updates.
- Restrict to a semver-compatible changes in the lockfile.
- Work around the issue with the `examples` package.