### PR TITLE
chore: update repository links to `nginx/ngx-rust`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ members = [
 [workspace.package]
 edition = "2021"
 license = "Apache-2.0"
-homepage = "https://github.com/nginxinc/ngx-rust"
-repository = "https://github.com/nginxinc/ngx-rust"
+homepage = "https://github.com/nginx/ngx-rust"
+repository = "https://github.com/nginx/ngx-rust"
 rust-version = "1.79.0"
 
 [package]

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -16,7 +16,7 @@ DOCKER_BUILD_FLAGS ?= --load
 COMMITSAR_DOCKER   := $(DOCKER) run --tty --rm --workdir /src -v "$(CURDIR):/src" aevea/commitsar
 COMMITSAR		   ?= $(shell command -v commitsar 2> /dev/null)
 PROJECT_NAME       ?= ngx-rust
-GITHUB_REPOSITORY  ?= nginxinc/$(PROJECT_NAME)
+GITHUB_REPOSITORY  ?= nginx/$(PROJECT_NAME)
 SRC_REPO           := https://github.com/$(GITHUB_REPOSITORY)
 
 RELEASE_BUILD_FLAGS ?= --quiet --release

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-[![Rust](https://github.com/nginxinc/ngx-rust/actions/workflows/ci.yaml/badge.svg)](https://github.com/nginxinc/ngx-rust/actions/workflows/ci.yaml)
+[![Rust](https://github.com/nginx/ngx-rust/actions/workflows/ci.yaml/badge.svg)](https://github.com/nginx/ngx-rust/actions/workflows/ci.yaml)
 [![crates.io](https://img.shields.io/crates/v/ngx.svg)](https://crates.io/crates/ngx)
 [![Project Status: Concept – Minimal or no implementation has been done yet, or the repository is only intended to be a limited example, demo, or proof-of-concept.](https://www.repostatus.org/badges/latest/concept.svg)](https://www.repostatus.org/#concept)
-[![Community Support](https://badgen.net/badge/support/community/cyan?icon=awesome)](https://github.com/nginxinc/ngx-rust/discussions)
+[![Community Support](https://badgen.net/badge/support/community/cyan?icon=awesome)](https://github.com/nginx/ngx-rust/discussions)
 
 
 ## Project status

--- a/examples/README.md
+++ b/examples/README.md
@@ -99,7 +99,7 @@ The following embedded variables are provided:
 
 1. Clone the git repository.
   ```
-  git clone git@github.com:nginxinc/ngx-rust.git
+  git clone git@github.com:nginx/ngx-rust.git
   ```
 
 2. Compile the module from the cloned repo.
@@ -197,7 +197,7 @@ http {
 
 1. Clone the git repository.
   ```
-  git clone git@github.com:nginxinc/ngx-rust.git
+  git clone git@github.com:nginx/ngx-rust.git
   ```
 
 2. Compile the module from the cloned repo.

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -153,7 +153,7 @@ unsafe impl Send for EventData {}
 unsafe impl Sync for EventData {}
 
 // same as ngx_post_event
-// source: https://github.com/nginxinc/ngx-rust/pull/31/files#diff-132330bb775bed17fb9990ec2b56e6c52e6a9e56d62f2114fade95e4decdba08R80-R90
+// source: https://github.com/nginx/ngx-rust/pull/31/files#diff-132330bb775bed17fb9990ec2b56e6c52e6a9e56d62f2114fade95e4decdba08R80-R90
 unsafe fn post_event(event: *mut ngx_event_t, queue: *mut ngx_queue_s) {
     let event = &mut (*event);
     if event.posted() == 0 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //! * `NGX_VERSION` (default 1.26.1) - NGINX OSS version
 //! * `NGX_DEBUG` (default to false) -  if set to true, then will compile NGINX `--with-debug` option
 //!
-//! For example, this is how you would compile the [examples](https://github.com/nginxinc/ngx-rust/tree/master/examples) using a specific version of NGINX and enabling
+//! For example, this is how you would compile the [examples](https://github.com/nginx/ngx-rust/tree/master/examples) using a specific version of NGINX and enabling
 //! debugging: `NGX_DEBUG=true NGX_VERSION=1.23.0 cargo build --package=examples --examples --release`
 //!
 //! To build Linux-only modules, use the "linux" feature: `cargo build --package=examples --examples --features=linux --release`


### PR DESCRIPTION
Updating all references to 'nginxinc' as a part of a move to the [nginx](https://github.com/nginx) GitHub organization.

GitHub leaves a redirect in place of a transferred repository, so all the external links to the nginxinc/ngx-rust will remain valid.
<https://crates.io/crates/ngx> will need a new release to pick up the changes.