### PR TITLE
fix(log): support nginx built without variadic macros

### DIFF
--- a/nginx-sys/build/main.rs
+++ b/nginx-sys/build/main.rs
@@ -25,6 +25,7 @@ const NGX_CONF_FEATURES: &[&str] = &[
     "have_epollrdhup",
     "have_file_aio",
     "have_kqueue",
+    "have_variadic_macros",
     "http_cache",
     "http_dav",
     "http_gzip",
@@ -254,7 +255,7 @@ fn expand_definitions<T: AsRef<Path>>(includes: &[T]) -> Result<Vec<u8>, Box<dyn
         writer,
         "
 #include <ngx_config.h>
-#include <nginx.h>
+#include <ngx_core.h>
 
 RUST_CONF_NGINX_BUILD=NGINX_VER_BUILD
 RUST_CONF_NGINX_VERSION=NGINX_VER


### PR DESCRIPTION
Fixed the error below, caused by a different signature of `ngx_log_error_core` when neither `NGX_HAVE_C99_VARIADIC_MACROS` nor nor `NGX_HAVE_GCC_VARIADIC_MACROS` is detected.
An example of affected configuration is MinGW with clang or gcc, where we skip most of the compiler feature checks.

```
error[E0061]: this function takes 5 arguments but 6 arguments were
supplied
     --> examples\awssig.rs:312:9
      |
312   |         ngx_log_debug_http!(request,  "headers {:?}",  headers);
      |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
unexpected argument #6 of type `*const u8`
      |
note: expected `*mut i8`,  found `usize`
```
