### PR TITLE
fix: inconsistent casing of FROM and AS in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG NGX_VERSION=1.26.1
 ARG NGX_DEBUG=false
 
 # --- builder: build all examples
-FROM rust:slim-bullseye as build
+FROM rust:slim-bullseye AS build
 ARG NGX_VERSION
 ARG NGX_DEBUG
 WORKDIR /project


### PR DESCRIPTION
### Proposed changes
This PR fixes an inconsistency in the casing of `FROM` and `AS` in the Dockerfile.  
Currently, `FROM` is uppercase while `as` is lowercase, which can trigger warnings in certain build environments.  
To maintain consistency and follow Dockerfile best practices, `AS` is now capitalized.

#### Warning message before the fix:

```
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 5)
```

There is no functional change in this PR; it is purely a stylistic improvement.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have written my commit messages in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.  
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc.  
- [ ] I have added tests (when possible) that prove my fix is effective or that my feature works.  
- [x] I have checked that all unit tests pass after adding my changes.  
- [ ] I have updated necessary documentation.  
- [x] I have rebased my branch onto master.  
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork.  