### PR TITLE
Docs: remove Safety notes from functions which are not `unsafe`; mark get_module_*_conf unsafe

### DIFF
--- a/nginx-sys/src/lib.rs
+++ b/nginx-sys/src/lib.rs
@@ -111,10 +111,6 @@ impl ngx_str_t {
 
     /// Convert the nginx string to a string slice (`&str`).
     ///
-    /// # Safety
-    /// This function is marked as unsafe because it involves raw pointer manipulation.
-    /// It assumes that the underlying `data` pointer is valid and points to a valid UTF-8 encoded string.
-    ///
     /// # Panics
     /// This function panics if the `ngx_str_t` is not valid UTF-8.
     ///

--- a/src/core/buffer.rs
+++ b/src/core/buffer.rs
@@ -13,18 +13,12 @@ pub trait Buffer {
     fn as_ngx_buf_mut(&mut self) -> *mut ngx_buf_t;
 
     /// Returns the buffer contents as a byte slice.
-    ///
-    /// # Safety
-    /// This function is marked as unsafe because it involves raw pointer manipulation.
     fn as_bytes(&self) -> &[u8] {
         let buf = self.as_ngx_buf();
         unsafe { slice::from_raw_parts((*buf).pos, self.len()) }
     }
 
     /// Returns the length of the buffer contents.
-    ///
-    /// # Safety
-    /// This function is marked as unsafe because it involves raw pointer manipulation.
     fn len(&self) -> usize {
         let buf = self.as_ngx_buf();
         unsafe {
@@ -68,9 +62,6 @@ pub trait Buffer {
 /// The `MutableBuffer` trait extends the `Buffer` trait and provides methods for working with a mutable buffer.
 pub trait MutableBuffer: Buffer {
     /// Returns a mutable reference to the buffer contents as a byte slice.
-    ///
-    /// # Safety
-    /// This function is marked as unsafe because it involves raw pointer manipulation.
     fn as_bytes_mut(&mut self) -> &mut [u8] {
         let buf = self.as_ngx_buf_mut();
         unsafe { slice::from_raw_parts_mut((*buf).pos, self.len()) }
@@ -105,9 +96,6 @@ impl Buffer for TemporaryBuffer {
 
 impl MutableBuffer for TemporaryBuffer {
     /// Returns a mutable reference to the buffer contents as a byte slice.
-    ///
-    /// # Safety
-    /// This function is marked as unsafe because it involves raw pointer manipulation.
     fn as_bytes_mut(&mut self) -> &mut [u8] {
         unsafe { slice::from_raw_parts_mut((*self.0).pos, self.len()) }
     }

--- a/src/core/pool.rs
+++ b/src/core/pool.rs
@@ -135,9 +135,6 @@ impl Pool {
     /// Allocates memory for a value of a specified type and adds a cleanup handler to the memory pool.
     ///
     /// Returns a typed pointer to the allocated memory if successful, or a null pointer if allocation or cleanup handler addition fails.
-    ///
-    /// # Safety
-    /// This function is marked as unsafe because it involves raw pointer manipulation.
     pub fn allocate<T>(&mut self, value: T) -> *mut T {
         unsafe {
             let p = self.alloc(mem::size_of::<T>()) as *mut T;

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -159,7 +159,7 @@ impl Request {
     ///
     /// # Safety
     /// Caller must ensure that type `T` matches the configuration type for the specified module.
-    pub fn get_module_main_conf<T>(&self, module: &ngx_module_t) -> Option<&'static T> {
+    pub unsafe fn get_module_main_conf<T>(&self, module: &ngx_module_t) -> Option<&'static T> {
         // SAFETY: main conf is either NULL or allocated with ngx_p(c)alloc and
         // explicitly initialized by the module
         unsafe {
@@ -174,7 +174,7 @@ impl Request {
     ///
     /// # Safety
     /// Caller must ensure that type `T` matches the configuration type for the specified module.
-    pub fn get_module_srv_conf<T>(&self, module: &ngx_module_t) -> Option<&'static T> {
+    pub unsafe fn get_module_srv_conf<T>(&self, module: &ngx_module_t) -> Option<&'static T> {
         // SAFETY: server conf is either NULL or allocated with ngx_p(c)alloc and
         // explicitly initialized by the module
         unsafe {
@@ -189,7 +189,7 @@ impl Request {
     ///
     /// # Safety
     /// Caller must ensure that type `T` matches the configuration type for the specified module.
-    pub fn get_module_loc_conf<T>(&self, module: &ngx_module_t) -> Option<&'static T> {
+    pub unsafe fn get_module_loc_conf<T>(&self, module: &ngx_module_t) -> Option<&'static T> {
         // SAFETY: location conf is either NULL or allocated with ngx_p(c)alloc and
         // explicitly initialized by the module
         unsafe {


### PR DESCRIPTION
### Proposed changes

This PR removes `# Safety` sections from the rustdocs of functions which are not `unsafe`. I noticed this when reading one of the docs and scanned through the entire repo's use of `# Safety` docs to collect this set. 

The `Request::get_module_*_conf` functions had `Safety` notes describing their invariants but were not `unsafe`, despite definitely being unsafe, so I changed those function signatures instead of removing the docs.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have written my commit messages in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have added tests (when possible) that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
