### PR TITLE
fix(examples): assorted fixes in the async example

### DIFF
--- a/.github/workflows/nginx.yaml
+++ b/.github/workflows/nginx.yaml
@@ -75,6 +75,7 @@ jobs:
         working-directory: nginx
         env:
           TEST_NGINX_GLOBALS: >-
+            load_module ${{ github.workspace }}/nginx/objs/ngx_http_async_module.so;
             load_module ${{ github.workspace }}/nginx/objs/ngx_http_awssigv4_module.so;
             load_module ${{ github.workspace }}/nginx/objs/ngx_http_curl_module.so;
             load_module ${{ github.workspace }}/nginx/objs/ngx_http_upstream_custom_module.so;

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -136,12 +136,12 @@ http_request_handler!(async_access_handler, |request: &mut http::Request| {
     }
 
     let event_data = unsafe {
-        let ctx = request.get_inner().ctx.add(ngx_http_async_module.ctx_index);
+        let ctx = request.as_ref().ctx.add(ngx_http_async_module.ctx_index);
         if (*ctx).is_null() {
             let ctx_data = &mut *(request.pool().alloc(std::mem::size_of::<RequestCTX>()) as *mut RequestCTX);
             ctx_data.event_data = Some(Arc::new(EventData {
                 done_flag: AtomicBool::new(false),
-                request: &request.get_inner() as *const _ as *mut _,
+                request: &request.as_ref() as *const _ as *mut _,
             }));
             *ctx = ctx_data as *const _ as _;
             ctx_data.event_data.as_ref().unwrap().clone()
@@ -191,7 +191,7 @@ http_request_handler!(async_access_handler, |request: &mut http::Request| {
     });
 
     unsafe {
-        (*request.get_inner().main).set_count((*request.get_inner().main).count() + 1);
+        (*request.as_ref().main).set_count((*request.as_ref().main).count() + 1);
     }
     core::Status::NGX_DONE
 });

--- a/examples/config
+++ b/examples/config
@@ -15,7 +15,7 @@ if [ $HTTP = YES ]; then
     ngx_rust_target_type=EXAMPLE
     ngx_rust_target_features=
 
-    if [ "$ngx_module_link" = DYNAMIC ]; then
+    if :; then
         ngx_module_name=ngx_http_async_module
         ngx_module_libs="-lm"
         ngx_rust_target_name=async

--- a/examples/t/async.t
+++ b/examples/t/async.t
@@ -1,0 +1,56 @@
+#!/usr/bin/perl
+
+# (C) Nginx, Inc
+
+# Tests for ngx-rust example modules.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http/)->plan(1)
+	->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        location / {
+            async on;
+        }
+    }
+}
+
+EOF
+
+$t->write_file('index.html', '');
+$t->run();
+
+###############################################################################
+
+like(http_get('/index.html'), qr/X-Async-Time:/, 'async handler');
+
+###############################################################################

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -7,3 +7,16 @@ pub use buffer::*;
 pub use pool::*;
 pub use status::*;
 pub use string::*;
+
+/// Gets an outer object pointer from a pointer to one of its fields.
+/// While there is no corresponding C macro, the pattern is common in the NGINX source.
+///
+/// # Safety
+///
+/// `$ptr` must be a valid pointer to the field `$field` of `$type`.
+#[macro_export]
+macro_rules! ngx_container_of {
+    ($ptr:expr, $type:path, $field:ident) => {
+        $ptr.byte_sub(::core::mem::offset_of!($type, $field)).cast::<$type>()
+    };
+}

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -101,6 +101,18 @@ impl<'a> From<&'a mut Request> for *mut ngx_http_request_t {
     }
 }
 
+impl AsRef<ngx_http_request_t> for Request {
+    fn as_ref(&self) -> &ngx_http_request_t {
+        &self.0
+    }
+}
+
+impl AsMut<ngx_http_request_t> for Request {
+    fn as_mut(&mut self) -> &mut ngx_http_request_t {
+        &mut self.0
+    }
+}
+
 impl Request {
     /// Create a [`Request`] from an [`ngx_http_request_t`].
     ///
@@ -401,11 +413,6 @@ impl Request {
     /// each header item is (&str, &str) (borrowed)
     pub fn headers_out_iterator(&self) -> NgxListIterator {
         unsafe { list_iterator(&self.0.headers_out.headers) }
-    }
-
-    /// Returns the inner data structure that the Request object is wrapping.
-    pub fn get_inner(&self) -> &ngx_http_request_t {
-        &self.0
     }
 }
 


### PR DESCRIPTION
* Use single tokio runtime instance. Move runtime initialization to the worker process.
* Use `ngx_posted_next_events` to avoid posting events to the tail of currently executed queue.
* Move `event` and `done` to the request context, remove `EventData`.
* Ensure the async task cancellation when the request is aborted.
* Test async example in CI.

[feat!: replace `Request.get_inner` with `AsRef`/`AsMut`](https://github.com/nginx/ngx-rust/commit/013f68c4502ac949f43a745c6f6c859e31aada49) technically does not belong here, but it's too small to deserve a PR on its own.