### PR TITLE
fix: empty string handling in NgxStr::from_ngx_str

### DIFF
--- a/src/core/string.rs
+++ b/src/core/string.rs
@@ -1,4 +1,3 @@
-use core::slice;
 use core::str::{self, Utf8Error};
 
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
@@ -39,7 +38,7 @@ impl NgxStr {
     /// to range of bytes of at least `len` bytes, whose content remains valid and doesn't
     /// change for the lifetime of the returned `NgxStr`.
     pub unsafe fn from_ngx_str<'a>(str: ngx_str_t) -> &'a NgxStr {
-        slice::from_raw_parts(str.data, str.len).into()
+        str.as_bytes().into()
     }
 
     /// Access the [`NgxStr`] as a byte slice.


### PR DESCRIPTION
A valid empty `ngx_str_t` is allowed to have an uninitialized data pointer, so calling `slice::from_raw_parts()` on it is not safe.
Thankfully, we've already solved this in `ngx_str_t::as_bytes()` and can just use the method.

Fixes #150