### PR TITLE
chore: address compiler warnings on nightly

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -17,7 +17,7 @@ fn main() {
     println!("cargo::rerun-if-env-changed=DEP_NGINX_FEATURES");
     if let Ok(features) = std::env::var("DEP_NGINX_FEATURES") {
         for feature in features.split(',').map(str::trim) {
-            println!("cargo::rustc-cfg=ngx_feature=\"{}\"", feature);
+            println!("cargo::rustc-cfg=ngx_feature=\"{feature}\"");
         }
     }
 
@@ -30,7 +30,7 @@ fn main() {
     // Read operating system detected by nginx-sys and pass to the compiler.
     println!("cargo::rerun-if-env-changed=DEP_NGINX_OS");
     if let Ok(os) = std::env::var("DEP_NGINX_OS") {
-        println!("cargo::rustc-cfg=ngx_os=\"{}\"", os);
+        println!("cargo::rustc-cfg=ngx_os=\"{os}\"");
     }
 
     // Generate cfg values for version checks

--- a/nginx-sys/build/vendored.rs
+++ b/nginx-sys/build/vendored.rs
@@ -395,11 +395,9 @@ fn download(cache_dir: &Path, url: &str) -> Result<PathBuf, Box<dyn StdError>> {
     }
 
     if !file_path.exists() {
-        return Err(format!(
-            "Downloaded file was not written to the expected location: {}",
-            url
-        )
-        .into());
+        return Err(
+            format!("Downloaded file was not written to the expected location: {url}",).into(),
+        );
     }
     Ok(file_path)
 }
@@ -425,14 +423,11 @@ fn verify_signature_file(cache_dir: &Path, signature_path: &Path) -> Result<(), 
 
         if !output.status.success() {
             eprintln!("{}", String::from_utf8_lossy(&output.stdout));
-            return Err(Box::new(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!(
-                    "Command: {:?} \nGPG signature file verification failed for signature: {}",
-                    cmd,
-                    signature_path.display()
-                ),
-            )));
+            return Err(Box::new(std::io::Error::other(format!(
+                "Command: {:?} \nGPG signature file verification failed for signature: {}",
+                cmd,
+                signature_path.display()
+            ))));
         }
     } else {
         println!("GPG not found, skipping signature file verification");
@@ -460,14 +455,11 @@ fn verify_archive_signature(
         let output = cmd.stderr_to_stdout().stdout_capture().unchecked().run()?;
         if !output.status.success() {
             eprintln!("{}", String::from_utf8_lossy(&output.stdout));
-            return Err(Box::new(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!(
-                    "Command: {:?}\nGPG signature verification failed of archive failed [{}]",
-                    cmd,
-                    archive_path.display()
-                ),
-            )));
+            return Err(Box::new(std::io::Error::other(format!(
+                "Command: {:?}\nGPG signature verification failed of archive failed [{}]",
+                cmd,
+                archive_path.display()
+            ))));
         }
     } else {
         println!("GPG not found, skipping signature verification");

--- a/nginx-sys/src/lib.rs
+++ b/nginx-sys/src/lib.rs
@@ -12,6 +12,7 @@ use core::slice;
 
 #[doc(hidden)]
 mod bindings {
+    #![allow(unknown_lints)] // unnecessary_transmutes
     #![allow(missing_docs)]
     #![allow(non_upper_case_globals)]
     #![allow(non_camel_case_types)]
@@ -20,6 +21,7 @@ mod bindings {
     #![allow(clippy::all)]
     #![allow(improper_ctypes)]
     #![allow(rustdoc::broken_intra_doc_links)]
+    #![allow(unnecessary_transmutes)]
     include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 }
 #[doc(no_inline)]

--- a/nginx-sys/src/queue.rs
+++ b/nginx-sys/src/queue.rs
@@ -34,7 +34,7 @@ pub unsafe fn ngx_queue_init(q: *mut ngx_queue_t) {
 /// `q` must be a valid pointer to [ngx_queue_t], initialized with [ngx_queue_init].
 #[inline]
 pub unsafe fn ngx_queue_empty(q: *const ngx_queue_t) -> bool {
-    q == (*q).prev
+    ptr::eq(q, (*q).prev)
 }
 
 /// Inserts a new node after the current.
@@ -190,7 +190,7 @@ mod tests {
         type Item = *mut ngx_queue_t;
 
         fn next(&mut self) -> Option<Self::Item> {
-            if self.h == self.q {
+            if ptr::eq(self.h, self.q) {
                 return None;
             }
 


### PR DESCRIPTION
- unwanted_transmutes on bindgen output
- [clippy::io_other_error](https://rust-lang.github.io/rust-clippy/master/index.html#io_other_error)
- [clippy::ptr_eq](https://rust-lang.github.io/rust-clippy/master/index.html#ptr_eq)
- [clippy::uninlined_format_args](https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args)