### PR TITLE
feat: a bit more useful NgxStr

### DIFF
--- a/nginx-sys/src/detail.rs
+++ b/nginx-sys/src/detail.rs
@@ -1,0 +1,112 @@
+//! Implementation details shared between nginx-sys and ngx.
+#![allow(missing_docs)]
+
+use core::fmt;
+
+#[inline]
+pub fn debug_bytes(f: &mut fmt::Formatter<'_>, bytes: &[u8]) -> fmt::Result {
+    if f.alternate() {
+        match bytes.len() {
+            0 => Ok(()),
+            1 => write!(f, "{:02x}", bytes[0]),
+            x => {
+                for b in &bytes[..x - 1] {
+                    write!(f, "{b:02x},")?;
+                }
+                write!(f, "{:02x}", bytes[x - 1])
+            }
+        }
+    } else {
+        f.write_str("\"")?;
+        display_bytes(f, bytes)?;
+        f.write_str("\"")
+    }
+}
+
+#[inline]
+pub fn display_bytes(f: &mut fmt::Formatter<'_>, bytes: &[u8]) -> fmt::Result {
+    // The implementation is similar to an inlined `String::from_utf8_lossy`, with two
+    // important differences:
+    //
+    //  - it writes directly to the Formatter instead of allocating a temporary String
+    //  - invalid sequences are represented as escaped individual bytes
+    for chunk in bytes.utf8_chunks() {
+        f.write_str(chunk.valid())?;
+        for byte in chunk.invalid() {
+            write!(f, "\\x{byte:02x}")?;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate alloc;
+    use alloc::format;
+    use alloc::string::ToString;
+
+    use super::*;
+
+    struct TestStr(&'static [u8]);
+
+    impl fmt::Debug for TestStr {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("TestStr(")?;
+            debug_bytes(f, self.0)?;
+            f.write_str(")")
+        }
+    }
+
+    impl fmt::Display for TestStr {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            display_bytes(f, self.0)
+        }
+    }
+
+    #[test]
+    fn test_display() {
+        let cases: &[(&[u8], &str)] = &[
+            (b"", ""),
+            (b"Ferris the \xf0\x9f\xa6\x80", "Ferris the 🦀"),
+            (b"\xF0\x90\x80", "\\xf0\\x90\\x80"),
+            (b"\xF0\x90\x80Hello World", "\\xf0\\x90\\x80Hello World"),
+            (b"Hello \xF0\x90\x80World", "Hello \\xf0\\x90\\x80World"),
+            (b"Hello World\xF0\x90\x80", "Hello World\\xf0\\x90\\x80"),
+        ];
+
+        for (bytes, expected) in cases {
+            let str = TestStr(bytes);
+            assert_eq!(str.to_string(), *expected);
+        }
+
+        // Check that the formatter arguments are ignored correctly
+        for (bytes, expected) in &cases[2..3] {
+            let str = TestStr(bytes);
+            assert_eq!(format!("{str:12.12}"), *expected);
+        }
+    }
+
+    #[test]
+    fn test_debug() {
+        let cases: &[(&[u8], &str, &str)] = &[
+            (b"", "TestStr(\"\")", "TestStr()"),
+            (b"a", "TestStr(\"a\")", "TestStr(61)"),
+            (
+                b"Ferris the \xf0\x9f\xa6\x80",
+                "TestStr(\"Ferris the 🦀\")",
+                "TestStr(46,65,72,72,69,73,20,74,68,65,20,f0,9f,a6,80)",
+            ),
+            (
+                b"\xF0\x90\x80",
+                "TestStr(\"\\xf0\\x90\\x80\")",
+                "TestStr(f0,90,80)",
+            ),
+        ];
+        for (bytes, expected, alternate) in cases {
+            let str = TestStr(bytes);
+            assert_eq!(format!("{str:?}"), *expected);
+            assert_eq!(format!("{str:#?}"), *alternate);
+        }
+    }
+}

--- a/nginx-sys/src/lib.rs
+++ b/nginx-sys/src/lib.rs
@@ -198,8 +198,7 @@ impl fmt::Display for ngx_str_t {
         for chunk in self.as_bytes().utf8_chunks() {
             f.write_str(chunk.valid())?;
             for byte in chunk.invalid() {
-                f.write_str("\\x")?;
-                fmt::LowerHex::fmt(byte, f)?;
+                write!(f, "\\x{byte:02x}")?;
             }
         }
         Ok(())
@@ -318,6 +317,7 @@ pub unsafe fn add_to_ngx_table(
 #[cfg(test)]
 mod tests {
     extern crate alloc;
+    use alloc::format;
     use alloc::string::ToString;
 
     use super::*;
@@ -339,6 +339,15 @@ mod tests {
                 len: bytes.len(),
             };
             assert_eq!(str.to_string(), *expected);
+        }
+
+        // Check that the formatter arguments are ignored correctly
+        for (bytes, expected) in &pairs[2..3] {
+            let str = ngx_str_t {
+                data: bytes.as_ptr().cast_mut(),
+                len: bytes.len(),
+            };
+            assert_eq!(format!("{str:12.12}"), *expected);
         }
     }
 }

--- a/nginx-sys/src/lib.rs
+++ b/nginx-sys/src/lib.rs
@@ -174,6 +174,20 @@ impl ngx_str_t {
     }
 }
 
+impl AsRef<[u8]> for ngx_str_t {
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        self.as_bytes()
+    }
+}
+
+impl AsMut<[u8]> for ngx_str_t {
+    #[inline]
+    fn as_mut(&mut self) -> &mut [u8] {
+        self.as_bytes_mut()
+    }
+}
+
 impl Default for ngx_str_t {
     fn default() -> Self {
         Self::empty()

--- a/src/core/string.rs
+++ b/src/core/string.rs
@@ -1,5 +1,6 @@
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 use alloc::{borrow::Cow, string::String};
+use core::fmt;
 use core::str::{self, Utf8Error};
 #[cfg(feature = "std")]
 use std::{borrow::Cow, string::String};
@@ -91,9 +92,26 @@ impl AsRef<[u8]> for NgxStr {
     }
 }
 
+impl fmt::Debug for NgxStr {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // XXX: Use debug_tuple() and feature(debug_closure_helpers) once it's stabilized
+        f.write_str("NgxStr(")?;
+        nginx_sys::detail::debug_bytes(f, &self.0)?;
+        f.write_str(")")
+    }
+}
+
 impl Default for &NgxStr {
     fn default() -> Self {
         NgxStr::from_bytes(&[])
+    }
+}
+
+impl fmt::Display for NgxStr {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        nginx_sys::detail::display_bytes(f, &self.0)
     }
 }
 

--- a/src/core/string.rs
+++ b/src/core/string.rs
@@ -24,6 +24,7 @@ macro_rules! ngx_string {
 /// Representation of a borrowed [Nginx string].
 ///
 /// [Nginx string]: https://nginx.org/en/docs/dev/development_guide.html#string_overview
+#[repr(transparent)]
 pub struct NgxStr([u_char]);
 
 impl NgxStr {
@@ -37,7 +38,15 @@ impl NgxStr {
     /// to range of bytes of at least `len` bytes, whose content remains valid and doesn't
     /// change for the lifetime of the returned `NgxStr`.
     pub unsafe fn from_ngx_str<'a>(str: ngx_str_t) -> &'a NgxStr {
-        str.as_bytes().into()
+        let bytes: &[u8] = str.as_bytes();
+        &*(bytes as *const [u8] as *const NgxStr)
+    }
+
+    /// Create an [NgxStr] from a borrowed byte slice.
+    #[inline]
+    pub fn from_bytes(bytes: &[u8]) -> &Self {
+        // SAFETY: An `NgxStr` is identical to a `[u8]` slice, given `u_char` is an alias for `u8`
+        unsafe { &*(bytes as *const [u8] as *const NgxStr) }
     }
 
     /// Access the [`NgxStr`] as a byte slice.
@@ -64,16 +73,15 @@ impl NgxStr {
     }
 }
 
-impl From<&[u8]> for &NgxStr {
-    fn from(bytes: &[u8]) -> Self {
-        // SAFETY: An `NgxStr` is identical to a `[u8]` slice, given `u_char` is an alias for `u8`.
-        unsafe { &*(bytes as *const [u8] as *const NgxStr) }
+impl<'a> From<&'a [u8]> for &'a NgxStr {
+    fn from(bytes: &'a [u8]) -> Self {
+        NgxStr::from_bytes(bytes)
     }
 }
 
-impl From<&str> for &NgxStr {
-    fn from(s: &str) -> Self {
-        s.as_bytes().into()
+impl<'a> From<&'a str> for &'a NgxStr {
+    fn from(s: &'a str) -> Self {
+        NgxStr::from_bytes(s.as_bytes())
     }
 }
 
@@ -85,7 +93,28 @@ impl AsRef<[u8]> for NgxStr {
 
 impl Default for &NgxStr {
     fn default() -> Self {
-        // SAFETY: The empty `ngx_str_t` is always a valid Nginx string.
-        unsafe { NgxStr::from_ngx_str(ngx_str_t::default()) }
+        NgxStr::from_bytes(&[])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate alloc;
+
+    use alloc::string::ToString;
+
+    use super::*;
+
+    #[test]
+    fn test_lifetimes() {
+        let a: &NgxStr = "Hello World!".into();
+
+        let s = "Hello World!".to_string();
+        let b: &NgxStr = NgxStr::from_bytes(s.as_bytes());
+
+        // The compiler should detect that s is borrowed and fail.
+        // drop(s); // ☢️
+
+        assert_eq!(a.0, b.0);
     }
 }


### PR DESCRIPTION
Prerequisite for the allocator-api work, but useful on its own.

* `nginx_sys::detail` could be another crate (`nginx-common`?), but there's just not enough code to split it now.
* no fancy `fmt::Debug` for `ngx_str_t`. Need to figure out how to override bindgen generated trait implementation without nuking Debug impls from most of the bindings. `Builder::no_debug()` does exactly that -- omits `Debug` on the `ngx_str_t` itself **and** on any structs that include `ngx_str_t` recursively.
* I attempted to implement precision and padding for `display_bytes`, but apparently precision requires a honest UTF-8 character width detection algorithm ([unicode-width](https://crates.io/crates/unicode-width)). The code without that can panic on an attempt to break an UTF-8 sequence. Maybe next time.
* Conversions and comparisons might be excessive. I took an inspiration from the [bstr](https://crates.io/crates/bstr) and left only types we realistically expect to use.
  I wish I could replace NgxStr with `bstr`, but it does not offer allocators support :(