### PR TITLE
nginx-sys: define ngx_list_init

### DIFF
--- a/nginx-sys/src/lib.rs
+++ b/nginx-sys/src/lib.rs
@@ -183,6 +183,34 @@ pub fn ngx_timeofday() -> &'static ngx_time_t {
     unsafe { &*ngx_cached_time }
 }
 
+/// Initialize a list, using a pool for the backing memory, with capacity to store the given number
+/// of elements and element size.
+///
+/// # Safety
+/// * `list` must be non-null
+/// * `pool` must be a valid pool
+#[inline]
+pub unsafe fn ngx_list_init(
+    list: *mut ngx_list_t,
+    pool: *mut ngx_pool_t,
+    n: ngx_uint_t,
+    size: usize,
+) -> ngx_int_t {
+    unsafe {
+        (*list).part.elts = ngx_palloc(pool, n * size);
+        if (*list).part.elts.is_null() {
+            return NGX_ERROR as ngx_int_t;
+        }
+        (*list).part.nelts = 0;
+        (*list).part.next = ptr::null_mut();
+        (*list).last = ptr::addr_of_mut!((*list).part);
+        (*list).size = size;
+        (*list).nalloc = n;
+        (*list).pool = pool;
+        NGX_OK as ngx_int_t
+    }
+}
+
 /// Add a key-value pair to an nginx table entry (`ngx_table_elt_t`) in the given nginx memory pool.
 ///
 /// # Arguments


### PR DESCRIPTION
Like many of the functions defined in nginx-sys, `ngx_list_init` is defined in nginx as an inline function in a C header, so it isnt captured by bindgen. This definition is equivalent to the one in the C header: https://github.com/nginx/nginx/blob/master/src/core/ngx_list.h#L36-L52

### Proposed changes
Describe the use case and detail of the change. If this PR addresses an issue 
on GitHub, make sure to include a link to that issue here in this description 
(not in the title of the PR).

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have written my commit messages in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have added tests (when possible) that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
