### PR TITLE
chore: replace references to master branch with main

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,5 +11,5 @@ Before creating a PR, run through this checklist and mark each as complete.
 - [ ] I have added tests (when possible) that prove my fix is effective or that my feature works
 - [ ] I have checked that all unit tests pass after adding my changes
 - [ ] I have updated necessary documentation
-- [ ] I have rebased my branch onto master
+- [ ] I have rebased my branch onto main
 - [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork

--- a/.github/workflows/cargo-deny.yaml
+++ b/.github/workflows/cargo-deny.yaml
@@ -2,7 +2,7 @@ name: cargo-deny
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 jobs:

--- a/.github/workflows/nginx.yaml
+++ b/.github/workflows/nginx.yaml
@@ -3,7 +3,7 @@ name: NGINX
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 env:

--- a/.github/workflows/sanitizers.yaml
+++ b/.github/workflows/sanitizers.yaml
@@ -3,7 +3,7 @@ name: sanitizers
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 env:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //! * `NGX_VERSION` (default 1.28.0) - NGINX OSS version
 //! * `NGX_DEBUG` (default to false) -  if set to true, then will compile NGINX `--with-debug` option
 //!
-//! For example, this is how you would compile the [examples](https://github.com/nginx/ngx-rust/tree/master/examples) using a specific version of NGINX and enabling
+//! For example, this is how you would compile the [examples](https://github.com/nginx/ngx-rust/tree/main/examples) using a specific version of NGINX and enabling
 //! debugging: `NGX_DEBUG=true NGX_VERSION=1.23.0 cargo build --package=examples --examples --release`
 //!
 //! To build Linux-only modules, use the "linux" feature: `cargo build --package=examples --examples --features=linux --release`


### PR DESCRIPTION
We are planning to rename the default branch from `master` to `main` before the next release, tentatively next week.

This seems to take care of all the _internal_ references to master. Unfortunately, nothing we can do with the external ones; hopefully there's not a lot of those.


