### PR TITLE
fix(auto): rename RUST_TARGET to NGX_RUST_TARGET

### DIFF
--- a/.github/workflows/sanitizers.yaml
+++ b/.github/workflows/sanitizers.yaml
@@ -69,8 +69,10 @@ jobs:
             -fno-omit-frame-pointer
             -fsanitize=address,undefined
           LDFLAGS: -fsanitize=address,undefined
-          RUST_TARGET: x86_64-unknown-linux-gnu
           RUSTFLAGS: -Zsanitizer=address -Zexternal-clangrt
+          # Pass --target to cargo to ensure that sanitizer flags are not
+          # applied to the build scripts and proc-macros.
+          NGX_RUST_TARGET: x86_64-unknown-linux-gnu
           # Extra options passed to cargo rustc
           NGX_RUSTC_OPT: -Zbuild-std
           # Enable unstable features, such as the -Z options above,

--- a/examples/auto/rust
+++ b/examples/auto/rust
@@ -250,21 +250,30 @@ ngx_rust_module () {
     ngx_module_libs_saved=$ngx_module_libs
     ngx_module_libs="$ngx_rust_obj $ngx_module_libs $RUST_LIBS"
 
-    # Module deps are usually added to the object file targets, but we don't have any
-    LINK_DEPS="$LINK_DEPS $ngx_rust_obj"
-
-    eval ${ngx_addon_id}_RUST_TARGETS=\"\$${ngx_addon_id}_RUST_TARGETS \
-                                        $ngx_rust_target_type:$ngx_rust_target_name\"
-
     if [ -n "$ngx_rust_target_features" ]; then
         eval ${ngx_addon_id}_RUST_FEATURES=\"\$${ngx_addon_id}_RUST_FEATURES \
                                              $ngx_rust_target_features\"
     fi
 
-   . auto/module
+    . auto/module
 
-   ngx_module_deps=$ngx_module_deps_saved
-   ngx_module_libs=$ngx_module_libs_saved
+    ngx_rust_target=$ngx_rust_target_type:$ngx_rust_target_name
+
+    # module deps are usually added to the object file targets, but we don't have any
+
+    if [ "$ngx_module_link" = DYNAMIC ]; then
+        # remember the dynamic module name and generate dependency later
+        ngx_rust_target=$ngx_rust_target:$ngx_module
+    else
+        # add dependency to the binary target
+        LINK_DEPS="$LINK_DEPS $ngx_rust_obj"
+    fi
+
+    eval ${ngx_addon_id}_RUST_TARGETS=\"\$${ngx_addon_id}_RUST_TARGETS \
+                                        $ngx_rust_target\"
+
+    ngx_module_deps=$ngx_module_deps_saved
+    ngx_module_libs=$ngx_module_libs_saved
 }
 
 
@@ -278,8 +287,9 @@ ngx_rust_make_modules () {
     eval ngx_rust_targets="\$${ngx_addon_id}_RUST_TARGETS"
 
     for target in $ngx_rust_targets; do
-        ngx_rust_target_type=${target%%:*}
-        ngx_rust_target_name=${target#*:}
+        IFS=':' read -r ngx_rust_target_type ngx_rust_target_name ngx_rust_module_name <<END
+$target
+END
 
         ngx_rust_make_module
     done
@@ -316,4 +326,14 @@ $ngx_rust_obj:
 		$ngx_rustc_module_opt $NGX_RUSTC_OPT
 
 END
+
+    # Ensure that the "auto"-generated dynamic module target depends on the
+    # static library. Normally this is achieved by attaching ADDON_DEPS to
+    # the module object files, but we don't have any suitable C sources.
+
+    if [ -n "$ngx_rust_module_name" ]; then
+        cat << END                                            >> $NGX_MAKEFILE
+$NGX_OBJS$ngx_dirsep$ngx_rust_module_name$ngx_modext:	$ngx_rust_obj
+END
+    fi
 }

--- a/examples/auto/rust
+++ b/examples/auto/rust
@@ -67,6 +67,12 @@
 #
 # ngx_rust_make_modules
 # ```
+#
+# The following environment variables can affect the generated Makefile:
+#
+# - NGX_CARGO sets the "cargo" binary to use, e.g. NGX_CARGO=cargo-1.82
+# - NGX_RUST_TARGET passes the --target to the Rust compiler if set
+# - NGX_RUSTC_OPT passes additional options to "cargo rustc"
 
 # Prevent duplicate invocation unless it is a newer library version
 if [ "${NGX_RUST_AUTO_VER:-0}" -ge 1 ]; then
@@ -136,7 +142,7 @@ case "$NGX_PLATFORM" in
                 RUST_LIBS="$RUST_LIBS userenv.lib"  # std::env::home_dir
                 RUST_LIBS="$RUST_LIBS dbghelp.lib"  # backtrace symbolization
 
-                RUST_TARGET=$RUST_TARGET_ARCH-pc-windows-msvc
+                NGX_RUST_TARGET=${NGX_RUST_TARGET:-$RUST_TARGET_ARCH-pc-windows-msvc}
             ;;
 
             gcc | clang)
@@ -145,7 +151,7 @@ case "$NGX_PLATFORM" in
                 RUST_LIBS="$RUST_LIBS -luserenv"
                 RUST_LIBS="$RUST_LIBS -ldbghelp"
                 # gnullvm on arm64?
-                RUST_TARGET=$RUST_TARGET_ARCH-pc-windows-gnu
+                NGX_RUST_TARGET=${NGX_RUST_TARGET:-$RUST_TARGET_ARCH-pc-windows-gnu}
             ;;
 
         esac
@@ -220,7 +226,7 @@ ngx_rust_target_path () {
         ngx_rust_obj=examples/$ngx_rust_obj
     fi
 
-    echo "${RUST_TARGET:+$RUST_TARGET/}$ngx_cargo_profile/$ngx_rust_obj"
+    echo "${NGX_RUST_TARGET:+$NGX_RUST_TARGET/}$ngx_cargo_profile/$ngx_rust_obj"
 }
 
 
@@ -304,7 +310,7 @@ $ngx_rust_obj:
 		--manifest-path "$ngx_cargo_manifest" \\
 		--no-default-features \\
 		--profile $ngx_cargo_profile \\
-		${RUST_TARGET:+--target $RUST_TARGET} \\
+		${NGX_RUST_TARGET:+--target $NGX_RUST_TARGET} \\
 		--target-dir $NGX_OBJS/$ngx_addon_id \\
 		--features "$ngx_rust_features" \\
 		$ngx_rustc_module_opt $NGX_RUSTC_OPT


### PR DESCRIPTION
This makes it more obvious that the variable is consumed by our script and not by the Rust toolchain itself.

Also, ensure that NGX_RUST_TARGET passed from the caller has priority over the detected value.