### PR TITLE
fix: skip invalid UTF-8 headers instead of panicking

### DIFF
--- a/examples/t/awssig.t
+++ b/examples/t/awssig.t
@@ -11,6 +11,8 @@ use strict;
 
 use Test::More;
 
+use Socket qw/ CRLF /;
+
 BEGIN { use FindBin; chdir($FindBin::Bin); }
 
 use lib 'lib';
@@ -21,7 +23,7 @@ use Test::Nginx;
 select STDERR; $| = 1;
 select STDOUT; $| = 1;
 
-my $t = Test::Nginx->new()->has(qw/http proxy/)->plan(1)
+my $t = Test::Nginx->new()->has(qw/http proxy/)->plan(2)
 	->write_file_expand('nginx.conf', <<"EOF");
 
 %%TEST_GLOBALS%%
@@ -69,5 +71,13 @@ $t->run();
 
 like(http_get('/'), qr/x-authorization: AWS4.*Credential=my-access-key/i,
 	'awssig header');
+
+like(http(
+    'GET / HTTP/1.0' . CRLF
+    . 'Foo: foo' . CRLF
+    . "Bar: \xFF\xFE\x80\x81" . CRLF
+	. "Host: localhost" . CRLF . CRLF
+), qr/x-authorization: AWS4.*Credential=my-access-key/,
+	'awssig invalid header ignored');
 
 ###############################################################################


### PR DESCRIPTION
Replace `to_str()` with explicit UTF-8 validation in NgxListIterator to handle malformed HTTP headers gracefully.
