### PR TITLE
test: enlarge the shared_dict zone for larger memory pages

### DIFF
--- a/examples/t/shared_dict.t
+++ b/examples/t/shared_dict.t
@@ -36,7 +36,7 @@ events {
 http {
     %%TEST_GLOBALS_HTTP%%
 
-    shared_dict_zone z 64k;
+    shared_dict_zone z 512k;
     shared_dict $arg_key $foo;
 
     server {


### PR DESCRIPTION
### Proposed changes

`examples/t/shared_dict.t` declares its zone as `64k`. That is 16 slab pages where a page is 4k, but only 4 pages where it is 16k. nginx dedicates a whole page to each slot size, so storing a key and a value that fall into different size classes consumes two of those four pages, and the third `shared_dict` write in the test runs out of zone:

```
*16 http script set var handler
*16 http script var: "fst"
slab alloc: 3 slot: 0
slab alloc: 9 slot: 1
[crit] ngx_slab_alloc() failed: no memory
slab alloc: 0000000000000000
```

`ngx_http_shared_dict_set_variable` drops the write silently when the allocation fails, so the request still returns `200` and three subtests fail later on a value that was never stored:

```
Failed tests:  6-7, 10
#   Failed test 'get entries - deleted'
#          '1; fst = hello; '
#     doesn't match '(?^ms:^1; fst = new_value; $)'
```

This reproduces on Apple Silicon macOS (16k pages) and applies equally to Linux arm64 builds configured with 16k or 64k pages. Only the 4k page systems CI currently runs on have enough room, which is why it has gone unnoticed.

`512k` keeps the zone at eight pages or more on 4k, 16k and 64k page systems alike, matching the minimum that nginx's own zone-backed modules enforce (`8 * ngx_pagesize`).

### Testing

`examples/t/shared_dict.t` against nginx 1.30.4 built from source on Apple Silicon (16k pages):

| zone | result |
| --- | --- |
| `64k` (current) | `Failed 3/14 subtests` |
| `256k` | `All tests successful` — but only 4 pages on a 64k page system |
| `512k` (this PR) | `All tests successful` |

I do not have a 4k page machine to hand, so I have not run it there; the change only grows the zone, and CI covers that configuration.

### Checklist

- [x] I have written my commit messages in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have added tests (when possible) that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
