### PR TITLE
ci: run the functional tests on macOS

### DIFF
--- a/.github/workflows/nginx.yaml
+++ b/.github/workflows/nginx.yaml
@@ -145,6 +145,69 @@ jobs:
         run: |
           prove -j$(nproc) --state=save ${NGX_TEST_FILES} || prove -v --state=failed
 
+  macos:
+    runs-on: macos-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        nginx-ref:
+          - stable-1.30
+        module:
+          - static
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ matrix.nginx-ref }}
+          repository: 'nginx/nginx'
+          path: 'nginx'
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: 'nginx/nginx-tests'
+          path: 'nginx/tests'
+          sparse-checkout: |
+            lib
+
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
+        with:
+          toolchain: stable
+
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            nginx/objs/**/CACHEDIR.TAG
+            nginx/objs/**/ngx-debug
+            nginx/objs/**/ngx-release
+          key: ${{ runner.os }}-nginx-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-nginx-
+
+      - name: Configure nginx with static modules
+        working-directory: nginx
+        run: |
+          ${NGX_CONFIGURE_CMD} \
+              ${NGX_CONFIGURE_UNIX} \
+              ${NGX_CONFIGURE_STATIC_MODULES}
+
+      - name: Build nginx
+        working-directory: nginx
+        run: make -j$(sysctl -n hw.ncpu)
+
+      - name: Run tests
+        env:
+          PERL5LIB: ${{ github.workspace }}/nginx/tests/lib
+          TEST_NGINX_BINARY: ${{ github.workspace }}/nginx/objs/nginx
+          TEST_NGINX_MODULES: ${{ github.workspace }}/nginx/objs
+          TEST_NGINX_VERBOSE: 1
+        run: |
+          prove -j$(sysctl -n hw.ncpu) --state=save ${NGX_TEST_FILES} \
+              || prove -v --state=failed
+
   windows:
     runs-on: windows-2022
     env:

--- a/examples/config
+++ b/examples/config
@@ -26,6 +26,9 @@ if [ $HTTP = YES ]; then
     if :; then
         ngx_module_name=ngx_http_awssigv4_module
         ngx_module_libs="-lm"
+        if [ "$NGX_SYSTEM" = Darwin ]; then
+            ngx_module_libs="$ngx_module_libs -framework CoreFoundation"
+        fi
         ngx_rust_target_name=awssig
 
         ngx_rust_module

--- a/examples/t/shared_dict.t
+++ b/examples/t/shared_dict.t
@@ -36,7 +36,7 @@ events {
 http {
     %%TEST_GLOBALS_HTTP%%
 
-    shared_dict_zone z 64k;
+    shared_dict_zone z 512k;
     shared_dict $arg_key $foo;
 
     server {


### PR DESCRIPTION
### Proposed changes

`prove examples/t` runs on the Linux and Windows jobs only. Both use 4k memory
pages, and the macOS job in `ci.yaml` runs `cargo test` without ever
configuring nginx with `--add-module`. So no job exercises the functional suite
on a system whose page size differs from 4k.

That gap hid a real failure: the 64k zone in `shared_dict.t` is sixteen pages
at 4k but only four at 16k, not enough to hold a key and a value that fall into
different slab size classes. The test failed on Apple Silicon while CI stayed
green (#318).

This adds a `macos` job to the NGINX workflow, mirroring the Linux one with a
single `stable-1.30` / `static` configuration to keep the added time modest.
`perl` and `prove` are already present on the runner image.

Running it turned up two further failures that no job could have seen before,
fixed in the first commit:

- **`awssig.t`** writes a config for a module that is no longer built on Darwin
  after #319, so nginx refuses to start. Skipped there now, matching the
  configure-time condition.
- **`shared_dict.t`** fails its three `check()` calls. `check()` records the
  worker pid that answered and retries back to back until a different one does,
  which is what proves the value came from shared memory rather than
  worker-local state. Consecutive connections keep landing on the worker that
  is already awake, so the loop exhausts without seeing a second pid. Pausing
  between retries spreads them.

### Testing

macOS 14.6, Apple Silicon, nginx 1.30.4.

Connection distribution, plain nginx with two workers and `return 200 "$pid"`:

| | split over 40 requests |
| --- | --- |
| back to back, as `check()` does | 38 / 2 |
| 0.2s between requests | 29 / 11 |

`shared_dict.t` in a loop:

| | failures |
| --- | --- |
| before | 50 / 50 |
| after | 0 / 50 |

`accept_mutex on` and `listen ... reuseport` were tried first; on this platform
each made the split worse, 40 / 0.

The whole of `examples/t`, run the way this job runs it, passes five times out
of five and still takes about 2s.

### Checklist

- [x] I have written my commit messages in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have added tests (when possible) that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
